### PR TITLE
Repoint YAM deploy docs at the shipped training launcher

### DIFF
--- a/experiments/yam/flexpi_policy/deploy_policy.py
+++ b/experiments/yam/flexpi_policy/deploy_policy.py
@@ -3,8 +3,7 @@
 Sister of ``experiments/robotwin/flexpi_policy/deploy_policy.py``.
 
 This file targets the YAM real-world FlexPiUnifiedJoint model trained by
-``scripts/yam_unified_joint_0509_4xh200_5ep.slurm``. Differences vs. the
-RoboTwin deploy:
+``scripts/train_flexpi_yam.sh``. Differences vs. the RoboTwin deploy:
 
 - Camera keys in observations are ``cam_high / cam_left_wrist / cam_right_wrist``
   (canonical RoboTwin-rename layout — same names the training dataset on
@@ -611,7 +610,7 @@ class YamFlexPiPolicy:
 
         ``observation`` keys are documented on the class docstring. Missing
         ``depth`` is supported only if the model's ``infer_action`` signature
-        does NOT declare ``per_cam_depth`` — for the YAM 0509 model it does,
+        does NOT declare ``per_cam_depth`` — for the YAM unified-joint model it does,
         so depth is required.
 
         When ``return_latents=True`` the return shape changes from
@@ -631,7 +630,7 @@ class YamFlexPiPolicy:
             if "depth" not in observation or observation["depth"] is None:
                 raise ValueError(
                     "Model signature declares `per_cam_depth` but observation['depth'] is missing. "
-                    "The YAM unified-joint 0509 model requires per-camera depth at deploy."
+                    "The YAM unified-joint model requires per-camera depth at deploy."
                 )
             per_cam_depth = self._build_per_cam_depth(observation["depth"])
             K = observation.get("intrinsics")
@@ -680,8 +679,9 @@ class YamFlexPiPolicy:
             # generation). Only the recorder path (return_latents=True) needs
             # them. Mirrors experiments/robotwin/flexpi_policy/deploy_policy.py.
             infer_kwargs["return_stream_latents"] = bool(return_latents)
-        # Models trained with per-cam RGB (RobotVideoDataset → YAM
-        # 0509 falls in this bucket) accept per_cam alongside the composite.
+        # Models trained with per-cam RGB (RobotVideoDataset → the YAM
+        # unified-joint model falls in this bucket) accept per_cam alongside
+        # the composite.
         if "per_cam" in self._infer_sig:
             infer_kwargs["per_cam"] = per_cam_rgb
         if per_cam_depth is not None:


### PR DESCRIPTION
Thanks for the release.

Rebased onto current main; see the comment below for what the client-side removal in afec3b5 made moot. As it stands this PR touches one file.

`experiments/yam/flexpi_policy/deploy_policy.py` points at `scripts/yam_unified_joint_0509_4xh200_5ep.slurm`. No `.slurm` file is in the published tree, and `scripts/train_flexpi_yam.sh` is what trains this model, so the module docstring is repointed there.

That filename was also the only place in the tree that defined what "0509" meant, so repointing it alone would orphan three surviving references, one of them in a string a user sees at runtime:

- `deploy_policy.py:6` — the module docstring
- `deploy_policy.py:614` — "for the YAM 0509 model it does"
- `deploy_policy.py:634` — the `ValueError` text "The YAM unified-joint 0509 model requires per-camera depth at deploy."
- `deploy_policy.py:684` — "0509 falls in this bucket"

Those become "YAM unified-joint", matching how the rest of the tree names the model. After the change `grep -rn 0509` over the tree returns nothing. Documentation and one user-facing string only, no behaviour change.

Two things from the original version of this PR are gone, both resolved on your side: the same dangling reference in `experiments/yam/flexpi_policy/README.md`, and the `--use_depth` argparse help in `yam_raiden_bridge_ws.py`. The stale `CKPT=runs/2026-05-13_*/step_008000.pt` example I asked about is gone from the rewritten README too, so there is nothing outstanding there either.