### PR TITLE
Lazy re-exports in experiments.yam.flexpi_policy so the unit tests run without torch

### DIFF
--- a/experiments/yam/flexpi_policy/__init__.py
+++ b/experiments/yam/flexpi_policy/__init__.py
@@ -1,1 +1,41 @@
-from .deploy_policy import YamFlexPiPolicy, build_policy_from_checkpoint  # noqa: F401
+"""YAM FlexPi deployment package.
+
+Re-exports are resolved lazily (PEP 562) so that importing this package does
+not pull in ``torch``, ``hydra`` and the full ``flexpi`` model stack. The
+lightweight modules here -- ``client_rtc_step_broker``, ``server_smoother``,
+``server_speed`` -- and their unit tests then run in any environment with
+numpy and pytest, which is what their module docstrings promise.
+
+``from experiments.yam.flexpi_policy import YamFlexPiPolicy`` still works and
+still imports the heavy stack on first attribute access.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+__all__ = [
+    "YamFlexPiPolicy",
+    "build_policy_from_checkpoint",
+]
+
+_LAZY = {
+    "YamFlexPiPolicy": ".deploy_policy",
+    "build_policy_from_checkpoint": ".deploy_policy",
+}
+
+
+def __getattr__(name: str):
+    module = _LAZY.get(name)
+    if module is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    from importlib import import_module
+
+    return getattr(import_module(module, __name__), name)
+
+
+def __dir__():
+    return sorted(__all__)
+
+
+if TYPE_CHECKING:  # import-time types for checkers only, never at runtime
+    from .deploy_policy import YamFlexPiPolicy, build_policy_from_checkpoint

--- a/experiments/yam/flexpi_policy/test_client_rtc_step_broker.py
+++ b/experiments/yam/flexpi_policy/test_client_rtc_step_broker.py
@@ -10,9 +10,11 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import numpy as np
 import pytest
 
-# Import the broker module DIRECTLY by path so we don't trigger the
-# `experiments.yam.flexpi_policy` package __init__ (which loads the whole
-# model). This makes the test runnable in any python env with numpy + pytest.
+# Import the broker module DIRECTLY by path, so this test never depends on the
+# `experiments.yam.flexpi_policy` package __init__. Note that pytest imports the
+# parent package during collection regardless of this, so what actually keeps
+# the test runnable in any python env with numpy + pytest is that the __init__
+# resolves its heavy re-exports lazily.
 _BROKER_PATH = (
     Path(__file__).resolve().parent / "client_rtc_step_broker.py"
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,3 +108,11 @@ trt = [
 [tool.setuptools.packages.find]
 where = ["src"]
 include = ["flexpi*"]
+
+[tool.pytest.ini_options]
+# Drop pytest's default `*_test.py` half of the glob. The only file it matches
+# is experiments/yam/flexpi_policy/smoke_test.py, which is a checkpoint-driven
+# CLI entrypoint rather than a test module, so `pytest experiments -q`
+# (docs/INSTALL.md section 3) would otherwise fail at collection trying to
+# import it.
+python_files = ["test_*.py"]


### PR DESCRIPTION
Rebased onto current main; see the comment below for what changed against the original version of this PR.

The package `__init__` imports `deploy_policy`, which imports `torch` and the `flexpi` model stack at module scope. pytest imports the parent package during collection, so every test file in that directory needs the full install — including `test_client_rtc_step_broker.py`, which loads the broker by file path for that reason and documents itself as runnable "in any python env with numpy + pytest". `docs/INSTALL.md` and `experiments/yam/flexpi_policy/README.md` both tell you to run `pytest experiments -q`.

Two changes:

1. Resolve the two surviving re-exports lazily (PEP 562), keeping `__all__` and `__dir__` so `import *` and `dir()` are unaffected. `from experiments.yam.flexpi_policy import YamFlexPiPolicy` still works and still imports the heavy stack, on first attribute access instead of at package import.
2. Set `python_files = ["test_*.py"]`. Lazy re-exports alone are not enough, because pytest's default glob is `test_*.py *_test.py` and the second half matches `smoke_test.py` — a checkpoint-driven CLI entrypoint, not a test module. `smoke_test.py` is the only file in the tree matching that half, so nothing else changes collection. The same change corrects the comment at the top of `test_client_rtc_step_broker.py`, which credited the by-path import for something it does not do.

**Verified** on current main in a venv with numpy 2.4.6 and pytest 9.1.1 and no torch installed, `pytest experiments/yam/flexpi_policy -q`:

- before: `4 errors during collection`, every one `ModuleNotFoundError: No module named 'torch'` — `smoke_test.py`, `test_client_rtc_step_broker.py`, `test_server_smoother.py`, `test_server_speed.py`
- after: `15 passed, 1 skipped`

**What I could not check:** I had no full `flexpi` environment here, so the lazily-loaded path is unexercised beyond confirming it dispatches to the right module. The one behavioural difference worth naming is that an ImportError from the heavy stack now surfaces at first attribute access rather than at package import.

If you would rather not take a test-discovery change in `pyproject.toml`, change 2 can be dropped and change 1 still stands on its own — `smoke_test.py` would keep failing collection.